### PR TITLE
Accept optional decorator argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function getMime (contenttype) {
   return null
 }
 
-function Application (opts) {
+function Application (opts, decorator) {
   var self = this
   opts.max = opts.max || 1000
 
@@ -179,6 +179,8 @@ function Application (opts) {
   })
 
   function onRequest (req, resp) {
+    if(typeof decorator === 'function') decorator(req, resp)
+    
     self.emit('request', req, resp)
   }
   self.httpServer = http.createServer(onRequest)
@@ -483,4 +485,4 @@ Cached.prototype.end = function (data) {
   this.emit('end')
 }
 
-module.exports = function (opts) {return new Application(opts || {})}
+module.exports = function (opts, decorator) {return new Application(opts || {}, decorator)}

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Application (opts, decorator) {
   var self = this
   opts.max = opts.max || 1000
 
+  self.cachable = opts.cachable || true
   self.lru = lrucache(opts)
   self.routes = new mapleTree.RouteTree()
   self.conditions = {}
@@ -267,7 +268,7 @@ function Route (app, pattern, cb) {
   var self = this
   self.app = app
   self.pattern = pattern
-  self._cachable = true
+  self._cachable = self.cachable
   self.conditions = {}
   if (cb) {
     self.request = function (req, resp) {

--- a/index.js
+++ b/index.js
@@ -179,9 +179,12 @@ function Application (opts, decorator) {
   })
 
   function onRequest (req, resp) {
-    if(typeof decorator === 'function') decorator(req, resp)
-    
-    self.emit('request', req, resp)
+    if(typeof decorator === 'function'){
+      decorator(req, resp, function(req, res){
+        self.emit('request', req, resp)
+      })
+    }
+    else self.emit('request', req, resp)
   }
   self.httpServer = http.createServer(onRequest)
   if (opts.ssl) self.httpsServer = https.createServer(opts.ssl, onRequest)


### PR DESCRIPTION
In order to allow for setup or "decoration" to occur for all requests, this will allow an optional second argument to be passed in to jaws, which will then be passed along to the http.createClient callback.

usage example:

``` js
var app = jaws({}, decorator)
function decorator(req, res){
  res.redirect = function(opts){...}
}
```
