### PR TITLE
Application#condition now handles status code and callback arguments cor...

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,13 +204,16 @@ Application.prototype.addHeader = function (name, value) {
 Application.prototype.condition = condition
 
 function condition (name, statusCode, handler) {
+  var unnamed = 'unnamed-'+Math.floor(Math.random()*111111111)
+
   if (!statusCode) {
     handler = name
     statusCode = 500
-    name = 'unnamed-'+Math.floor(Math.random()*111111111)
+    name = unnamed
   } else if (!handler) {
     handler = statusCode
-    statusCode = 500
+    statusCode = typeof name === 'string' ? 500 : name
+    name = typeof name === 'string' ? name : unnamed
   }
 
   this.conditions[name] = [statusCode, handler]

--- a/tests/test-conditions.js
+++ b/tests/test-conditions.js
@@ -28,7 +28,7 @@ app.route('/no', function (req, resp) {
   resp.statusCode = 200
   resp.end('ok')
 })
-.condition(function (req, resp, cb) {
+.condition(403, function (req, resp, cb) {
   cb(new Error('no options'))
 })
 
@@ -69,7 +69,7 @@ app.httpServer.listen(8080, function () {
   
   var r = request.post('http://localhost:8080/no', function (e, resp, body) {
     if (e) throw e
-    assert.equal(500, resp.statusCode)
+    assert.equal(403, resp.statusCode)
     assert.notEqual('ok', body)
     done()
   })


### PR DESCRIPTION
...rectly.

If you do this `condition(statusCode, cb)`, as in the README examples:

```
.condition(401, function (req, resp, cb) {
  req.on('condition.auth', function (e, user) {
    if (req.user.id !== req.routes.params.userid) return cb('You can only access your own user document.')
    cb(null, user)
  })
})
```

The 401 status code is ignored and 500 gets sent instead.

This commit corrects that.
Not completely happy about the logic, but it works.
