### PR TITLE
also cache responses with statusCode 304

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ function Application (opts) {
 
             if (!self.cacheErrors)
               resp.once('finish', function () {
-                if (resp.statusCode !== 200)
+                if (resp.statusCode !== 200 && resp.statusCode !== 304)
                   self.lru.del(u)
               })
 


### PR DESCRIPTION
We currently only caches if the response give back a statusCode of 200, but should also allow 304 - right now a file isn't cached when it's in the browser cache.
