### PR TITLE
check if data is compressible before doing a gzip on it

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var fs = require('fs')
   , mapleTree = require('mapleTree')
   , lrucache = require('lru-cache')
   , safeStringify = require('json-stringify-safe')
+  , compressible = require('compressible')
   ;
 
 function getMime (contenttype) {
@@ -456,6 +457,12 @@ Cached.prototype.end = function (data) {
   this.buffer = buffer
   this.md5 = crypto.createHash('md5').update(this.buffer).digest("hex")
   this.headers['etag'] = this.md5
+
+  if (!compressible(this.headers['content-type'])) {
+    self.ended = true
+    self.emit('end')
+    return
+  }
 
   zlib.gzip(buffer, function (e, compressed) {
     if (e) return self.emit('error', e)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "mime": "~1.2.9",
     "mapleTree": "~0.5.0-1",
     "lru-cache": "~2.2.2",
-    "json-stringify-safe": "~3.0.0"
+    "json-stringify-safe": "~3.0.0",
+    "compressible": "~1.0.0"
   },
   "devDependencies": {
     "request": "~2.10.0"


### PR DESCRIPTION
We should probably not gzip already compressed data, for example images.
